### PR TITLE
Sanity: Add icons to document types

### DIFF
--- a/studio/package.json
+++ b/studio/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "@sanity/document-internationalization": "^2.0.1",
+    "@sanity/icons": "^2.4.1",
     "@sanity/ui": "^1.8.2",
     "@sanity/vision": "^3.16.4",
     "react": "^18.2.0",

--- a/studio/pnpm-lock.yaml
+++ b/studio/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@sanity/document-internationalization':
     specifier: ^2.0.1
     version: 2.0.1(@babel/core@7.22.15)(@sanity/ui@1.8.2)(react-dom@18.2.0)(react-fast-compare@3.2.2)(react-is@18.2.0)(react@18.2.0)(rxjs@7.8.1)(sanity@3.16.4)(styled-components@5.3.11)
+  '@sanity/icons':
+    specifier: ^2.4.1
+    version: 2.4.1(react@18.2.0)
   '@sanity/ui':
     specifier: ^1.8.2
     version: 1.8.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.11)

--- a/studio/schemas/author.ts
+++ b/studio/schemas/author.ts
@@ -1,9 +1,11 @@
 import {defineField, defineType} from 'sanity'
+import {UserIcon} from '@sanity/icons'
 
 export default defineType({
   name: 'author',
   title: 'Author',
   type: 'document',
+  icon: UserIcon,
   fields: [
     defineField({
       name: 'name',

--- a/studio/schemas/category.ts
+++ b/studio/schemas/category.ts
@@ -1,9 +1,11 @@
 import {defineField, defineType} from 'sanity'
+import {TagIcon} from '@sanity/icons'
 
 export default defineType({
   name: 'category',
   title: 'Category',
   type: 'document',
+  icon: TagIcon,
   fields: [
     defineField({
       name: 'title',

--- a/studio/schemas/post.ts
+++ b/studio/schemas/post.ts
@@ -1,10 +1,12 @@
 import {defineField, defineType} from 'sanity'
+import {ComposeIcon} from '@sanity/icons'
 import { uniqueSlugByLanguage } from '../utils/uniqueSlugByLanguage'
 
 export default defineType({
   name: 'post',
   title: 'Post',
   type: 'document',
+  icon: ComposeIcon,
   groups: [
     {
       name: "content",

--- a/studio/schemas/supportedLanguages.ts
+++ b/studio/schemas/supportedLanguages.ts
@@ -1,10 +1,12 @@
 import {defineField, defineType} from 'sanity'
-import { DefaultLanguage } from '../components/DefaultLanguage'
+import {TranslateIcon} from '@sanity/icons'
+import {DefaultLanguage} from '../components/DefaultLanguage'
 
 export default defineType({
   name: 'supportedLanguages',
   title: 'Languages',
   type: 'document',
+  icon: TranslateIcon,
   fields: [
     defineField({
       name: 'id',


### PR DESCRIPTION
| Before | After |
| :-: | :-: |
| ![image](https://github.com/bryceknz/sanity-translations-experiment/assets/25199713/8caba902-2fc0-4a5d-8695-2cc69de38e58) | ![image](https://github.com/bryceknz/sanity-translations-experiment/assets/25199713/d0e4e839-c576-429e-8415-1ee155c65ff4) |

Closes #30.